### PR TITLE
re-download if cached version is incorrect

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -225,7 +225,7 @@ describe('setup-node', () => {
     await main.run();
 
     expect(logSpy).toHaveBeenCalledWith(
-      `Found v14.0.0 in cache @ ${toolPath} but it does not satisfy the requested version (12.16.2)`
+      `Found v14.0.0 in cache @ ${expPath} but it does not satisfy the requested version (12.16.2)`
     );
     expect(logSpy).toHaveBeenCalledWith(
       `Attempting to download ${versionSpec}...`

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -205,6 +205,27 @@ describe('setup-node', () => {
     expect(cnSpy).toHaveBeenCalledWith(`::add-path::${expPath}${osm.EOL}`);
   });
 
+  it('finds incorrect version in cache and adds it to the path', async () => {
+    let versionSpec = '12.16.2';
+    inputs['node-version'] = versionSpec;
+
+    inSpy.mockImplementation(name => inputs[name]);
+    getExecOutputSpy.mockImplementation(() => 'v12.0.0');
+
+    let toolPath = path.normalize('/cache/node/12.16.1/x64');
+    findSpy.mockImplementation(() => toolPath);
+    await main.run();
+
+    let expPath = path.join(toolPath, 'bin');
+    expect(logSpy).toHaveBeenCalledWith(
+      `Found v12.0.0 in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      `Attempting to download ${versionSpec}...`
+    );
+    expect(cnSpy).toHaveBeenCalledWith(`::add-path::${expPath}${osm.EOL}`);
+  });
+
   it('handles unhandled find error and reports error', async () => {
     let errMsg = 'unhandled error message';
     inputs['node-version'] = '12';

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -59931,7 +59931,7 @@ exports.supportedPackageManagers = {
     },
     pnpm: {
         lockFilePatterns: ['pnpm-lock.yaml'],
-        getCacheFolderCommand: 'pnpm store path'
+        getCacheFolderCommand: 'pnpm store path --silent'
     },
     yarn1: {
         lockFilePatterns: ['yarn.lock'],
@@ -59986,7 +59986,7 @@ exports.getCacheDirectoryPath = (packageManagerInfo, packageManager) => __awaite
         throw new Error(`Could not get cache folder path for ${packageManager}`);
     }
     core.debug(`${packageManager} path is ${stdOut}`);
-    return stdOut;
+    return stdOut.trim();
 });
 function isGhes() {
     const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71846,7 +71846,7 @@ function run() {
                 yield installer.getNode(version, stable, checkLatest, auth, arch);
             }
             // Output version of node is being used
-            const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true });
+            const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true, silent: false });
             core.setOutput('node-version', installedVersion);
             const registryUrl = core.getInput('registry-url');
             const alwaysAuth = core.getInput('always-auth');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71847,8 +71847,8 @@ function run() {
             }
             // Output version of node is being used
             try {
-                const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true, silent: false });
-                core.setOutput('node-version', installedVersion);
+                const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true, silent: true });
+                core.setOutput('node-version', installedVersion.trim());
             }
             catch (err) {
                 core.setOutput('node-version', '');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71277,7 +71277,7 @@ exports.supportedPackageManagers = {
     },
     pnpm: {
         lockFilePatterns: ['pnpm-lock.yaml'],
-        getCacheFolderCommand: 'pnpm store path'
+        getCacheFolderCommand: 'pnpm store path --silent'
     },
     yarn1: {
         lockFilePatterns: ['yarn.lock'],
@@ -71332,7 +71332,7 @@ exports.getCacheDirectoryPath = (packageManagerInfo, packageManager) => __awaite
         throw new Error(`Could not get cache folder path for ${packageManager}`);
     }
     core.debug(`${packageManager} path is ${stdOut}`);
-    return stdOut;
+    return stdOut.trim();
 });
 function isGhes() {
     const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71846,17 +71846,13 @@ function run() {
                 yield installer.getNode(version, stable, checkLatest, auth, arch);
             }
             // Output version of node is being used
-            let installedVersion = '';
-            const result = yield exec.exec('node', ['--version'], {
-                ignoreReturnCode: true,
-                silent: false,
-                listeners: {
-                    stdout: data => {
-                        installedVersion = data.toString();
-                    }
-                }
-            });
-            core.setOutput('node-version', installedVersion);
+            try {
+                const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true, silent: false });
+                core.setOutput('node-version', installedVersion);
+            }
+            catch (err) {
+                core.setOutput('node-version', '');
+            }
             const registryUrl = core.getInput('registry-url');
             const alwaysAuth = core.getInput('always-auth');
             if (registryUrl) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71846,7 +71846,16 @@ function run() {
                 yield installer.getNode(version, stable, checkLatest, auth, arch);
             }
             // Output version of node is being used
-            const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true, silent: false });
+            let installedVersion = '';
+            const result = yield exec.exec('node', ['--version'], {
+                ignoreReturnCode: true,
+                silent: false,
+                listeners: {
+                    stdout: data => {
+                        installedVersion = data.toString();
+                    }
+                }
+            });
             core.setOutput('node-version', installedVersion);
             const registryUrl = core.getInput('registry-url');
             const alwaysAuth = core.getInput('always-auth');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71448,11 +71448,16 @@ function getNode(versionSpec, stable, checkLatest, auth, arch = os.arch()) {
         // If not found in cache, download
         if (toolPath) {
             core.info(`Found in cache @ ${toolPath}`);
-            const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true });
-            if (!semver.satisfies(installedVersion, versionSpec)) {
-                core.info(`Found ${installedVersion} in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`);
-                toolPath = '';
+            if (osPlat != 'win32') {
+                toolPath = path.join(toolPath, 'bin');
             }
+            core.addPath(toolPath);
+            const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true });
+            if (semver.satisfies(installedVersion, versionSpec)) {
+                return;
+            }
+            core.info(`Found ${installedVersion} in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`);
+            toolPath = '';
         }
         if (!toolPath) {
             core.info(`Attempting to download ${versionSpec}...`);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -71409,6 +71409,7 @@ const core = __importStar(__nccwpck_require__(2186));
 const hc = __importStar(__nccwpck_require__(9925));
 const io = __importStar(__nccwpck_require__(7436));
 const tc = __importStar(__nccwpck_require__(7784));
+const exec = __importStar(__nccwpck_require__(1514));
 const path = __importStar(__nccwpck_require__(1017));
 const semver = __importStar(__nccwpck_require__(5911));
 const fs = __nccwpck_require__(7147);
@@ -71447,8 +71448,13 @@ function getNode(versionSpec, stable, checkLatest, auth, arch = os.arch()) {
         // If not found in cache, download
         if (toolPath) {
             core.info(`Found in cache @ ${toolPath}`);
+            const { stdout: installedVersion } = yield exec.getExecOutput('node', ['--version'], { ignoreReturnCode: true });
+            if (!semver.satisfies(installedVersion, versionSpec)) {
+                core.info(`Found ${installedVersion} in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`);
+                toolPath = '';
+            }
         }
-        else {
+        if (!toolPath) {
             core.info(`Attempting to download ${versionSpec}...`);
             let downloadPath = '';
             let info = null;

--- a/src/cache-utils.ts
+++ b/src/cache-utils.ts
@@ -18,7 +18,7 @@ export const supportedPackageManagers: SupportedPackageManagers = {
   },
   pnpm: {
     lockFilePatterns: ['pnpm-lock.yaml'],
-    getCacheFolderCommand: 'pnpm store path'
+    getCacheFolderCommand: 'pnpm store path --silent'
   },
   yarn1: {
     lockFilePatterns: ['yarn.lock'],
@@ -94,7 +94,7 @@ export const getCacheDirectoryPath = async (
 
   core.debug(`${packageManager} path is ${stdOut}`);
 
-  return stdOut;
+  return stdOut.trim();
 };
 
 export function isGhes(): boolean {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -82,18 +82,25 @@ export async function getNode(
   if (toolPath) {
     core.info(`Found in cache @ ${toolPath}`);
 
+    if (osPlat != 'win32') {
+      toolPath = path.join(toolPath, 'bin');
+    }
+
+    core.addPath(toolPath);
+
     const {stdout: installedVersion} = await exec.getExecOutput(
       'node',
       ['--version'],
       {ignoreReturnCode: true}
     );
 
-    if (!semver.satisfies(installedVersion, versionSpec)) {
-      core.info(
-        `Found ${installedVersion} in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`
-      );
-      toolPath = '';
+    if (semver.satisfies(installedVersion, versionSpec)) {
+      return;
     }
+    core.info(
+      `Found ${installedVersion} in cache @ ${toolPath} but it does not satisfy the requested version (${versionSpec})`
+    );
+    toolPath = '';
   }
 
   if (!toolPath) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as installer from './installer';
 import fs from 'fs';
+import * as child_process from 'child_process';
 import * as auth from './authutil';
 import * as path from 'path';
 import {restoreCache} from './cache-restore';
@@ -45,9 +46,9 @@ export async function run() {
       const {stdout: installedVersion} = await exec.getExecOutput(
         'node',
         ['--version'],
-        {ignoreReturnCode: true, silent: false}
+        {ignoreReturnCode: true, silent: true}
       );
-      core.setOutput('node-version', installedVersion);
+      core.setOutput('node-version', installedVersion.trim());
     } catch (err) {
       core.setOutput('node-version', '');
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,17 +41,16 @@ export async function run() {
     }
 
     // Output version of node is being used
-    let installedVersion = '';
-    const result = await exec.exec('node', ['--version'], {
-      ignoreReturnCode: true,
-      silent: false,
-      listeners: {
-        stdout: data => {
-          installedVersion = data.toString();
-        }
-      }
-    });
-    core.setOutput('node-version', installedVersion);
+    try {
+      const {stdout: installedVersion} = await exec.getExecOutput(
+        'node',
+        ['--version'],
+        {ignoreReturnCode: true, silent: false}
+      );
+      core.setOutput('node-version', installedVersion);
+    } catch (err) {
+      core.setOutput('node-version', '');
+    }
 
     const registryUrl: string = core.getInput('registry-url');
     const alwaysAuth: string = core.getInput('always-auth');

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as installer from './installer';
 import fs from 'fs';
-import * as child_process from 'child_process';
 import * as auth from './authutil';
 import * as path from 'path';
 import {restoreCache} from './cache-restore';

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ export async function run() {
     const {stdout: installedVersion} = await exec.getExecOutput(
       'node',
       ['--version'],
-      {ignoreReturnCode: true}
+      {ignoreReturnCode: true, silent: false}
     );
     core.setOutput('node-version', installedVersion);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,11 +41,16 @@ export async function run() {
     }
 
     // Output version of node is being used
-    const {stdout: installedVersion} = await exec.getExecOutput(
-      'node',
-      ['--version'],
-      {ignoreReturnCode: true, silent: false}
-    );
+    let installedVersion = '';
+    const result = await exec.exec('node', ['--version'], {
+      ignoreReturnCode: true,
+      silent: false,
+      listeners: {
+        stdout: data => {
+          installedVersion = data.toString();
+        }
+      }
+    });
     core.setOutput('node-version', installedVersion);
 
     const registryUrl: string = core.getInput('registry-url');


### PR DESCRIPTION
**Description:**
Sometimes the cached version is corrupt, and contains a different version than expected.

This PR checks the found cached version, and attempts to re-download if it doesn't match.

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.